### PR TITLE
Use Correct Values for GB Pan

### DIFF
--- a/src/CGBChannel.cpp
+++ b/src/CGBChannel.cpp
@@ -55,10 +55,10 @@ uint8_t CGBChannel::GetOwner()
 void CGBChannel::SetVol(uint8_t vol, int8_t pan)
 {
     if (eState < EnvState::REL) {
-        if (pan < -32) {
+        if (pan < -21) {
             // snap left
             this->pan = Pan::LEFT;
-        } else if (pan > 32) {
+        } else if (pan > 20) {
             // snap right
             this->pan = Pan::RIGHT;
         } else {


### PR DESCRIPTION
Fixes Issue #19 
The current values for determining GB pan snapping (-32 and 32) are not accurate. I found these values through testing using an actual GBA ROM, so they should be accurate.