### PR TITLE
Change Modulation Behavior to Be More Accurate

### DIFF
--- a/src/StreamGenerator.cpp
+++ b/src/StreamGenerator.cpp
@@ -134,17 +134,20 @@ void StreamGenerator::processSequenceTick()
 
         isSongRunning = true;
         
+        if (cTrk.mod > 0)
+            cTrk.lfoPhase = uint8_t(cTrk.lfoPhase + cTrk.lfos);
+        else
+            cTrk.lfoPhase = 0; // if mod is 0, set phase to 0 too
         if (sm.TickTrackNotes(uint8_t(ntrk), cTrk.activeNotes) > 0) {
             if (cTrk.lfodlCount > 0) {
                 cTrk.lfodlCount--;
                 cTrk.lfoPhase = 0;
-            } else {
-                cTrk.lfoPhase = uint8_t(cTrk.lfoPhase + cTrk.lfos);
             }
-        } else {
-            cTrk.lfoPhase = 0;
+        } else
             cTrk.lfodlCount = cTrk.lfodl;
-        }
+        if ((cTrk.lfodl == cTrk.lfodlCount && cTrk.lfodl != 0) || (cTrk.lfos == 0))
+            cTrk.lfoPhase = 0;
+
         // count down last delay and process
         bool updatePV = false;
         if (--cTrk.delay <= 0) {


### PR DESCRIPTION
Previously, in agbplay, the lfo phase would only change when there was at least one active note playing on the track. However, in m4a, the lfo phase actually gets incremented every tick, whether or not there is a note being played, as long as both the mod value and lfos value are greater than zero.