### PR TITLE
Change Loop Behavior to Be Configurable, Add Support for Endless Looping

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Take a look at this sample scheme:
     "id" : "agbplay",
     "cgb-polyphony" : "mono-strict",
     "wave-output-dir" : "/home/misterx/Music/agbplay",
+    "max-loops-export" : 1,
+    "max-loops-playlist" : 1,
     "playlists" : 
     [
         {
@@ -108,6 +110,8 @@ The root element in the JSON has the following properties:
 - `playlists` contains the array of the actual tagged songs. See below for details.
 - `wave-output-dir` specifies the directory which is used for exporting songs from agbplay.
 - `cgb-polyphony` specifies whether CGB sounds should be allowed to be polyphonic. Valid values are `mono-strict`, `mono-smooth`, `poly`.
+- `max-loops-export` specifies how many times songs should loop before fading out when exporting to a file.
+- `max-loops-playlist` specifies how many times songs should loop before fading out when listening to a song within the program. This value can be set to `-1` to make songs loop endlessly.
 
 Each playlist entry in the array contains the following properties:
 

--- a/agbplay.json
+++ b/agbplay.json
@@ -1,6 +1,8 @@
 {
 	"cgb-polyphony" : "mono-strict",
 	"id" : "agbplay",
+	"max-loops-export" : 1,
+	"max-loops-playlist" : 1,
 	"playlists" : 
 	[
 		{

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -177,7 +177,7 @@ CGBPolyphony ConfigManager::GetCgbPolyphony()
 
 int8_t ConfigManager::GetMaxLoopsPlaylist()
 {
-    return maxLoopsPlaylist;
+    return maxLoopsPlaylist < -1 ? 0 : maxLoopsPlaylist;
 }
 
 int8_t ConfigManager::GetMaxLoopsExport()

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -81,6 +81,10 @@ void ConfigManager::Load()
 
     // CGB channel polyphony configuration
     confCgbPolyphony = str2cgbPoly(root.get("cgb-polyphony", "mono-strict").asString());
+    
+    // Loop configuration
+    maxLoopsPlaylist = static_cast<int8_t>(root.get("max-loops-playlist", 1).asInt());
+    maxLoopsExport = static_cast<int8_t>(root.get("max-loops-export", 1).asInt());
 
     for (Json::Value playlist : root["playlists"]) {
         // parse games
@@ -143,6 +147,8 @@ void ConfigManager::Save()
     root["wav-output-dir"] = confWavOutputDir.string();
     root["cgb-polyphony"] = cgbPoly2str(confCgbPolyphony);
     root["playlists"] = playlists;
+    root["max-loops-playlist"] = maxLoopsPlaylist;
+    root["max-loops-export"] = maxLoopsExport;
 
     std::filesystem::create_directories(configPath.parent_path());
     std::ofstream jsonFile(configPath);
@@ -167,4 +173,14 @@ const std::filesystem::path& ConfigManager::GetWavOutputDir()
 CGBPolyphony ConfigManager::GetCgbPolyphony()
 {
     return confCgbPolyphony;
+}
+
+int8_t ConfigManager::GetMaxLoopsPlaylist()
+{
+    return maxLoopsPlaylist;
+}
+
+int8_t ConfigManager::GetMaxLoopsExport()
+{
+    return maxLoopsExport < 0 ? 0 : maxLoopsExport;
 }

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -17,6 +17,8 @@ public:
     void Save();
     const std::filesystem::path& GetWavOutputDir();
     CGBPolyphony GetCgbPolyphony();
+    int8_t GetMaxLoopsPlaylist();
+    int8_t GetMaxLoopsExport();
 private:
     ConfigManager() = default;
     ConfigManager(const ConfigManager&) = delete;
@@ -24,6 +26,8 @@ private:
     std::vector<GameConfig> configs;
     std::filesystem::path confWavOutputDir;
     CGBPolyphony confCgbPolyphony;
+    int8_t maxLoopsPlaylist;
+    int8_t maxLoopsExport;
     std::filesystem::path configPath;
     GameConfig *curCfg = nullptr;
 };

--- a/src/PlayerContext.cpp
+++ b/src/PlayerContext.cpp
@@ -1,7 +1,7 @@
 #include "PlayerContext.h"
 #include "ConfigManager.h"
 
-PlayerContext::PlayerContext(uint8_t maxLoops, uint8_t maxTracks, EnginePars pars)
+PlayerContext::PlayerContext(int8_t maxLoops, uint8_t maxTracks, EnginePars pars)
     : reader(*this, maxLoops), mixer(*this, STREAM_SAMPLERATE, 1.0f), seq(maxTracks), pars(pars)
 {
 }

--- a/src/PlayerContext.h
+++ b/src/PlayerContext.h
@@ -11,7 +11,7 @@
  * to a PlayerContext */
 
 struct PlayerContext {
-    PlayerContext(uint8_t maxLoops, uint8_t maxTracks, EnginePars pars);
+    PlayerContext(int8_t maxLoops, uint8_t maxTracks, EnginePars pars);
     PlayerContext(const PlayerContext&) = delete;
     PlayerContext& operator=(const PlayerContext&) = delete;
 

--- a/src/PlayerInterface.cpp
+++ b/src/PlayerInterface.cpp
@@ -11,9 +11,6 @@
 #include "Util.h"
 #include "ConfigManager.h"
 
-// TODO replace this with a config option
-#define MAX_LOOPS 1
-
 /*
  * PlayerInterface data
  */
@@ -227,7 +224,7 @@ void PlayerInterface::initContext()
     /* We could make the context a member variable instead of
      * a unique_ptr, but initialization get's a little messy that way */
     ctx = std::make_unique<PlayerContext>(
-            MAX_LOOPS,
+            ConfigManager::Instance().GetMaxLoopsPlaylist(),
             cfg.GetTrackLimit(),
             EnginePars(cfg.GetPCMVol(), cfg.GetEngineRev(), cfg.GetEngineFreq())
             );

--- a/src/SequenceReader.cpp
+++ b/src/SequenceReader.cpp
@@ -10,6 +10,7 @@
 
 #define NOTE_TIE -1
 #define NOTE_ALL 0xFE
+#define LOOP_ENDLESS -1
 
 /*
  * SequenceReader data
@@ -43,7 +44,7 @@ const std::map<uint8_t, int8_t> SequenceReader::noteLut = {
  * public SequenceReader
  */
 
-SequenceReader::SequenceReader(PlayerContext& ctx, uint8_t maxLoops) 
+SequenceReader::SequenceReader(PlayerContext& ctx, int8_t maxLoops) 
     : ctx(ctx), maxLoops(maxLoops)
 {
 }
@@ -210,7 +211,7 @@ void SequenceReader::processSequenceTick()
                         case 0xB2:
                             // GOTO
                             if (ntrk == 0) {
-                                if (numLoops++ >= maxLoops && !endReached) {
+                                if (maxLoops != LOOP_ENDLESS && numLoops++ >= maxLoops && !endReached) {
                                     endReached = true;
                                     ctx.mixer.StartFadeOut(SONG_FADE_OUT_TIME);
                                 }

--- a/src/SequenceReader.h
+++ b/src/SequenceReader.h
@@ -30,7 +30,7 @@ private:
     PlayerContext& ctx;
 
     bool endReached = false;
-    int8_t maxLoops = 1;
+    const int8_t maxLoops = 1;
     uint8_t numLoops = 0;
     float speedFactor = 1.0f;
 

--- a/src/SequenceReader.h
+++ b/src/SequenceReader.h
@@ -12,7 +12,7 @@ struct PlayerContext;
 class SequenceReader
 {
 public:
-    SequenceReader(PlayerContext& ctx, uint8_t maxLoops);
+    SequenceReader(PlayerContext& ctx, int8_t maxLoops);
     SequenceReader(const SequenceReader&) = delete;
     SequenceReader& operator=(const SequenceReader&) = delete;
 
@@ -30,7 +30,7 @@ private:
     PlayerContext& ctx;
 
     bool endReached = false;
-    const uint8_t maxLoops;
+    int8_t maxLoops = 1;
     uint8_t numLoops = 0;
     float speedFactor = 1.0f;
 

--- a/src/SoundExporter.cpp
+++ b/src/SoundExporter.cpp
@@ -69,7 +69,7 @@ size_t SoundExporter::exportSong(const std::filesystem::path& fileName, uint16_t
 
     
     PlayerContext ctx(
-            1, 
+            ConfigManager::Instance().GetMaxLoopsExport(),
             cfg.GetTrackLimit(),
             EnginePars(cfg.GetPCMVol(), cfg.GetEngineRev(), cfg.GetEngineFreq())
             );


### PR DESCRIPTION
Previously, you had to recompile the program every time you wanted to change the number of times songs loop, which was annoying. Now they are configurable at run-time through the .json file with separate values being used for when playing a song in the program (max-loops-playlist) and when exporting to a file (max-loops-export). Additionally, support for endless looping has been added; setting max-loops-playlist to -1 will enable it.