### PR TITLE
Fix `swap` on `vector<bool>`

### DIFF
--- a/src/PlaylistGUI.cpp
+++ b/src/PlaylistGUI.cpp
@@ -186,6 +186,6 @@ void PlaylistGUI::swapEntry(uint32_t a, uint32_t b)
     if (a >= s || b >= s)
         return;
     std::swap(cfg.GetGameEntries()[a], cfg.GetGameEntries()[b]);
-    std::swap(ticked[a], ticked[b]);
+    std::vector<bool>::swap(ticked[a], ticked[b]);
     update();
 }


### PR DESCRIPTION
The project doesn't compile on latest Arch Linux. Seems like `std::swap` is not supported on `std::vector<bool>` on latest `gcc-libs` (11.2.0-4). I replaced it with the more specific `std::vector<bool>::swap`.