### PR TITLE
Add option to export with desired bit depth (16, 24, 32 float)

### DIFF
--- a/src/agbplay-gui/SettingsWindow.cpp
+++ b/src/agbplay-gui/SettingsWindow.cpp
@@ -53,7 +53,7 @@ QDialog(parent), ui(new Ui::SettingsWindow), settings(settings)
     assert(exportComboBoxIndex >= 0);
     ui->exportSampleRateComboBox->setCurrentIndex(exportComboBoxIndex);
 
-    /* init bits per sample combo box */
+    /* init bit depth combo box */
     for (const auto v : standardBits) {
         const auto s = QString::fromStdString(fmt::format("{}-bit", v));
         ui->exportBitDepthComboBox->addItem(s, QVariant(v));

--- a/src/agbplay-gui/SettingsWindow.cpp
+++ b/src/agbplay-gui/SettingsWindow.cpp
@@ -1,5 +1,4 @@
 #include "SettingsWindow.hpp"
-
 #include "Settings.hpp"
 #include "ui_SettingsWindow.h"
 
@@ -13,9 +12,10 @@
 
 static const std::vector<uint32_t> standardRates = {22050, 32000, 44100, 48000, 96000, 192000};
 static const uint32_t RATE_CUSTOM = 0u;
+static const std::vector<uint32_t> standardBits = {16, 24, 32};
 
 SettingsWindow::SettingsWindow(QWidget *parent, Settings &settings) :
-    QDialog(parent), ui(new Ui::SettingsWindow), settings(settings)
+QDialog(parent), ui(new Ui::SettingsWindow), settings(settings)
 {
     ui->setupUi(this);
 
@@ -52,6 +52,17 @@ SettingsWindow::SettingsWindow(QWidget *parent, Settings &settings) :
     exportComboBoxIndex = ui->exportSampleRateComboBox->findData(QVariant(settings.exportSampleRate));
     assert(exportComboBoxIndex >= 0);
     ui->exportSampleRateComboBox->setCurrentIndex(exportComboBoxIndex);
+
+    /* init bits per sample combo box */
+    for (const auto v : standardBits) {
+        const auto s = QString::fromStdString(fmt::format("{}-bit", v));
+        ui->exportBitDepthComboBox->addItem(s, QVariant(v));
+    }
+
+    it = std::find(standardBits.begin(), standardBits.end(), settings.exportBitDepth);
+    exportComboBoxIndex = ui->exportBitDepthComboBox->findData(QVariant(settings.exportBitDepth));
+    assert(exportBitDepthComboBoxIndex = 0);
+    ui->exportBitDepthComboBox->setCurrentIndex(exportComboBoxIndex);
 
     /* init other fields */
     ui->exportPadStartSpinBox->setValue(settings.exportPadStart);
@@ -170,6 +181,7 @@ void SettingsWindow::buttonBoxButtonPressed(QAbstractButton *button)
     /* if OK or apply was pressed, apply changes to settings */
     settings.playbackSampleRate = std::max(1u, ui->playbackSampleRateComboBox->currentData().toUInt());
     settings.exportSampleRate = std::max(1u, ui->exportSampleRateComboBox->currentData().toUInt());
+    settings.exportBitDepth = std::max(1u, ui->exportBitDepthComboBox->currentData().toUInt());
     settings.exportPadStart = std::clamp(ui->exportPadStartSpinBox->value(), 0.0, 100.0);
     settings.exportPadEnd = std::clamp(ui->exportPadEndSpinBox->value(), 0.0, 100.0);
     settings.exportQuickExportDirectory = ui->exportFolderLineEdit->text().toStdWString();

--- a/src/agbplay-gui/SettingsWindow.ui
+++ b/src/agbplay-gui/SettingsWindow.ui
@@ -47,7 +47,7 @@
        <layout class="QGridLayout" name="gridLayout_4">
         <item row="0" column="0">
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="3" column="0" colspan="2">
+          <item row="4" column="0" colspan="2">
            <widget class="QGroupBox" name="exportFolderGroupBox">
             <property name="title">
              <string>Auto quick export to folder</string>
@@ -91,23 +91,33 @@
            </widget>
           </item>
           <item row="1" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Bit Depth</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
            <widget class="QLabel" name="label_3">
             <property name="text">
              <string>Silence at Start</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="exportSampleRateComboBox"/>
-          </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
              <string>Silence at End</string>
             </property>
            </widget>
           </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="exportSampleRateComboBox"/>
+          </item>
           <item row="1" column="1">
+           <widget class="QComboBox" name="exportBitDepthComboBox"/>
+          </item>
+          <item row="2" column="1">
            <widget class="QDoubleSpinBox" name="exportPadStartSpinBox">
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -123,7 +133,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QDoubleSpinBox" name="exportPadEndSpinBox">
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/agbplay/Settings.cpp
+++ b/src/agbplay/Settings.cpp
@@ -10,6 +10,7 @@
 static const std::filesystem::path CONFIG_PATH = OS::GetLocalConfigDirectory() / "agbplay" / "config.json";
 static const std::filesystem::path DEFAULT_EXPORT_DIRECTORY = OS::GetMusicDirectory() / "agbplay";
 static const uint32_t DEFAULT_SAMPLERATE = 48000;
+static const uint32_t DEFAULT_BIT_DEPTH = 32;
 static const bool DEFAULT_QUICK_EXPORT_ASK = true;
 
 void Settings::Load()
@@ -23,6 +24,7 @@ void Settings::Load()
             /* If the config does not exist, this is a normal use case and we silently initialize a standard config. */
             playbackSampleRate = DEFAULT_SAMPLERATE;
             exportSampleRate = DEFAULT_SAMPLERATE;
+            exportBitDepth = DEFAULT_BIT_DEPTH;
             exportQuickExportDirectory = DEFAULT_EXPORT_DIRECTORY;
             exportQuickExportAsk = DEFAULT_QUICK_EXPORT_ASK;
             return;
@@ -44,6 +46,12 @@ void Settings::Load()
         exportSampleRate = std::max<uint32_t>(1u, j["exportSampleRate"]);
     } else {
         exportSampleRate = DEFAULT_SAMPLERATE;
+    }
+
+    if (j.contains("exportBitDepth") && j["exportBitDepth"].is_number()) {
+        exportBitDepth = std::max<uint32_t>(1u, j["exportBitDepth"]);
+    } else {
+        exportBitDepth = DEFAULT_BIT_DEPTH;
     }
 
     if (j.contains("exportPadStart") && j["exportPadStart"].is_number()) {
@@ -79,6 +87,7 @@ void Settings::Save()
     json j;
     j["playbackSampleRate"] = playbackSampleRate;
     j["exportSampleRate"] = exportSampleRate;
+    j["exportBitDepth"] = exportBitDepth;
     j["exportPadStart"] = exportPadStart;
     j["exportPadEnd"] = exportPadEnd;
     j["exportQuickExportDirectory"] = exportQuickExportDirectory;

--- a/src/agbplay/Settings.hpp
+++ b/src/agbplay/Settings.hpp
@@ -12,6 +12,7 @@ struct Settings
     uint32_t playbackSampleRate = 0;
 
     uint32_t exportSampleRate = 0;
+    uint32_t exportBitDepth = 0;
     double exportPadStart = 0.0;
     double exportPadEnd = 0.0;
     std::filesystem::path exportQuickExportDirectory;

--- a/src/agbplay/SoundExporter.cpp
+++ b/src/agbplay/SoundExporter.cpp
@@ -137,6 +137,15 @@ size_t SoundExporter::exportSong(const std::filesystem::path &filePath, uint16_t
     size_t nTracks = ctx.players.at(playerIdx).tracksUsed;
     const double padSecondsStart = settings.exportPadStart;
     const double padSecondsEnd = settings.exportPadEnd;
+    int bitDepth = SF_FORMAT_PCM_16;
+
+    if (settings.exportBitDepth == 16) {
+        bitDepth = SF_FORMAT_PCM_16;
+    } else if (settings.exportBitDepth == 24) {
+        bitDepth = SF_FORMAT_PCM_24;
+    } else {
+        bitDepth = SF_FORMAT_FLOAT;
+    }
 
     if (!benchmarkOnly) {
         /* save each track to a separate file */
@@ -148,7 +157,7 @@ size_t SoundExporter::exportSong(const std::filesystem::path &filePath, uint16_t
                 memset(&oinfos[i], 0, sizeof(oinfos[i]));
                 oinfos[i].samplerate = static_cast<int>(settings.exportSampleRate);
                 oinfos[i].channels = 2;    // stereo
-                oinfos[i].format = SF_FORMAT_WAV | SF_FORMAT_FLOAT;
+                oinfos[i].format = SF_FORMAT_WAV | bitDepth;
                 std::filesystem::path finalFilePath = filePath;
                 finalFilePath += fmt::format(".{:02d}.wav", i);
 #ifdef _WIN32
@@ -193,7 +202,7 @@ size_t SoundExporter::exportSong(const std::filesystem::path &filePath, uint16_t
             memset(&oinfo, 0, sizeof(oinfo));
             oinfo.samplerate = static_cast<int>(settings.exportSampleRate);
             oinfo.channels = 2;    // sterep
-            oinfo.format = SF_FORMAT_WAV | SF_FORMAT_FLOAT;
+            oinfo.format = SF_FORMAT_WAV | bitDepth;
             std::filesystem::path finalFilePath = filePath;
             finalFilePath += fmt::format(".wav");
 #ifdef _WIN32


### PR DESCRIPTION
I've added the possibility of choosing the bit depth with which the tracks are exported. I've chosen some of today's standard depths (16-bit and 24-bit) in addition to the 32-bit floating already present, so that users don't need to resample a second time with another program if 32-bit floating doesn't suit. What's more, this allows tracks to be exported more quickly, taking up less storage space. And it completes the possibility of choosing the sample rate of tracks.

I've done my best to ensure that my code integrates perfectly with yours, but I hope I've done it right as this is the first time I've contributed to a C++ project. ^^"