### PR TITLE
Export: bit depth overhaul

### DIFF
--- a/src/agbplay-gui/SettingsWindow.hpp
+++ b/src/agbplay-gui/SettingsWindow.hpp
@@ -22,7 +22,8 @@ public:
 
 private:
     void playbackComboBoxActivated(int index);
-    void exportComboBoxActivated(int index);
+    void exportSampleRateComboBox(int index);
+    void exportBitDepthComboBoxActivated(int index);
     void updateComboBoxRate(QComboBox *comboBox, int &index, const int indexActivated);
     void exportPushButtonPressed(bool);
     void buttonBoxButtonPressed(QAbstractButton *button);

--- a/src/agbplay/Settings.cpp
+++ b/src/agbplay/Settings.cpp
@@ -11,6 +11,7 @@ static const std::filesystem::path CONFIG_PATH = OS::GetLocalConfigDirectory() /
 static const std::filesystem::path DEFAULT_EXPORT_DIRECTORY = OS::GetMusicDirectory() / "agbplay";
 static const uint32_t DEFAULT_SAMPLERATE = 48000;
 static const uint32_t DEFAULT_BIT_DEPTH = 32;
+static const std::string DEFAULT_BIT_FORMAT = "FP";
 static const bool DEFAULT_QUICK_EXPORT_ASK = true;
 
 void Settings::Load()
@@ -25,6 +26,7 @@ void Settings::Load()
             playbackSampleRate = DEFAULT_SAMPLERATE;
             exportSampleRate = DEFAULT_SAMPLERATE;
             exportBitDepth = DEFAULT_BIT_DEPTH;
+            exportBitFormat = DEFAULT_BIT_FORMAT;
             exportQuickExportDirectory = DEFAULT_EXPORT_DIRECTORY;
             exportQuickExportAsk = DEFAULT_QUICK_EXPORT_ASK;
             return;
@@ -52,6 +54,12 @@ void Settings::Load()
         exportBitDepth = std::max<uint32_t>(1u, j["exportBitDepth"]);
     } else {
         exportBitDepth = DEFAULT_BIT_DEPTH;
+    }
+
+    if (j.contains("exportBitFormat") && j["exportBitFormat"].is_string()) {
+        exportBitFormat = j["exportBitFormat"];
+    } else {
+        exportBitFormat = DEFAULT_BIT_FORMAT;
     }
 
     if (j.contains("exportPadStart") && j["exportPadStart"].is_number()) {
@@ -88,6 +96,7 @@ void Settings::Save()
     j["playbackSampleRate"] = playbackSampleRate;
     j["exportSampleRate"] = exportSampleRate;
     j["exportBitDepth"] = exportBitDepth;
+    j["exportBitFormat"] = exportBitFormat;
     j["exportPadStart"] = exportPadStart;
     j["exportPadEnd"] = exportPadEnd;
     j["exportQuickExportDirectory"] = exportQuickExportDirectory;

--- a/src/agbplay/Settings.hpp
+++ b/src/agbplay/Settings.hpp
@@ -13,6 +13,8 @@ struct Settings
 
     uint32_t exportSampleRate = 0;
     uint32_t exportBitDepth = 0;
+    std::string exportBitFormat = "";
+    void exportBitDepthComboBoxActivated(int index);
     double exportPadStart = 0.0;
     double exportPadEnd = 0.0;
     std::filesystem::path exportQuickExportDirectory;

--- a/src/agbplay/SoundExporter.cpp
+++ b/src/agbplay/SoundExporter.cpp
@@ -92,15 +92,15 @@ void SoundExporter::Export()
         Debug::print("Successfully wrote {} files", profile.playlist.size());
     } else {
         const uint64_t secondsTotal =
-        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::seconds>(endTime - startTime).count());
+            static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::seconds>(endTime - startTime).count());
         const uint64_t microSecondsTotal =
-        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count());
+            static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count());
         const uint64_t samplesPerSecond = totalSamplesRendered * 1000000 / microSecondsTotal;
         Debug::print(
             "Successfully wrote {} files at {} samples per second ({} seconds total)",
-                     profile.playlist.size(),
-                     samplesPerSecond,
-                     secondsTotal
+            profile.playlist.size(),
+            samplesPerSecond,
+            secondsTotal
         );
     }
 }
@@ -123,10 +123,10 @@ size_t SoundExporter::exportSong(const std::filesystem::path &filePath, uint16_t
     MP2KContext ctx(
         settings.exportSampleRate,
         Rom::Instance(),
-                    profile.mp2kSoundModePlayback,
-                    profile.agbplaySoundMode,
-                    profile.songTableInfoPlayback,
-                    profile.playerTablePlayback
+        profile.mp2kSoundModePlayback,
+        profile.agbplaySoundMode,
+        profile.songTableInfoPlayback,
+        profile.playerTablePlayback
     );
 
     ctx.m4aSongNumStart(uid);
@@ -173,11 +173,11 @@ size_t SoundExporter::exportSong(const std::filesystem::path &filePath, uint16_t
                 oinfos[i].format = SF_FORMAT_WAV | dataFormat;
                 std::filesystem::path finalFilePath = filePath;
                 finalFilePath += fmt::format(".{:02d}.wav", i);
-                #ifdef _WIN32
+#ifdef _WIN32
                 ofiles[i] = sf_wchar_open(finalFilePath.wstring().c_str(), SFM_WRITE, &oinfos[i]);
-                #else
+#else
                 ofiles[i] = sf_open(finalFilePath.string().c_str(), SFM_WRITE, &oinfos[i]);
-                #endif
+#endif
                 if (ofiles[i] == NULL)
                     Debug::print("Error: {}", sf_strerror(NULL));
                 else
@@ -221,11 +221,11 @@ size_t SoundExporter::exportSong(const std::filesystem::path &filePath, uint16_t
             oinfo.format = SF_FORMAT_WAV | dataFormat;
             std::filesystem::path finalFilePath = filePath;
             finalFilePath += fmt::format(".wav");
-            #ifdef _WIN32
+#ifdef _WIN32
             SNDFILE *ofile = sf_wchar_open(finalFilePath.wstring().c_str(), SFM_WRITE, &oinfo);
-            #else
+#else
             SNDFILE *ofile = sf_open(finalFilePath.string().c_str(), SFM_WRITE, &oinfo);
-            #endif
+#endif
             if (ofile == NULL) {
                 Debug::print("Error: {}", sf_strerror(NULL));
                 return 0;

--- a/src/agbplay/SoundExporter.cpp
+++ b/src/agbplay/SoundExporter.cpp
@@ -153,15 +153,12 @@ size_t SoundExporter::exportSong(const std::filesystem::path &filePath, uint16_t
     switch(settings.exportBitDepth) {
         case 8:
             dataFormat = SF_FORMAT_PCM_U8;
-            useIntWrite = true;
             break;
         case 16:
             dataFormat = SF_FORMAT_PCM_16;
-            useIntWrite = true;
             break;
         case 24:
             dataFormat = SF_FORMAT_PCM_24;
-            useIntWrite = true;
             break;
         case 32:
             if (settings.exportBitFormat == "PCM") {

--- a/src/agbplay/SoundExporter.cpp
+++ b/src/agbplay/SoundExporter.cpp
@@ -92,15 +92,15 @@ void SoundExporter::Export()
         Debug::print("Successfully wrote {} files", profile.playlist.size());
     } else {
         const uint64_t secondsTotal =
-        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::seconds>(endTime - startTime).count());
+            static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::seconds>(endTime - startTime).count());
         const uint64_t microSecondsTotal =
-        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count());
+            static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count());
         const uint64_t samplesPerSecond = totalSamplesRendered * 1000000 / microSecondsTotal;
         Debug::print(
             "Successfully wrote {} files at {} samples per second ({} seconds total)",
-                     profile.playlist.size(),
-                     samplesPerSecond,
-                     secondsTotal
+            profile.playlist.size(),
+            samplesPerSecond,
+            secondsTotal
         );
     }
 }
@@ -133,10 +133,10 @@ size_t SoundExporter::exportSong(const std::filesystem::path &filePath, uint16_t
     MP2KContext ctx(
         settings.exportSampleRate,
         Rom::Instance(),
-                    profile.mp2kSoundModePlayback,
-                    profile.agbplaySoundMode,
-                    profile.songTableInfoPlayback,
-                    profile.playerTablePlayback
+        profile.mp2kSoundModePlayback,
+        profile.agbplaySoundMode,
+        profile.songTableInfoPlayback,
+        profile.playerTablePlayback
     );
 
     ctx.m4aSongNumStart(uid);
@@ -188,11 +188,11 @@ size_t SoundExporter::exportSong(const std::filesystem::path &filePath, uint16_t
                 oinfos[i].format = SF_FORMAT_WAV | dataFormat;
                 std::filesystem::path finalFilePath = filePath;
                 finalFilePath += fmt::format(".{:02d}.wav", i);
-                #ifdef _WIN32
+#ifdef _WIN32
                 ofiles[i] = sf_wchar_open(finalFilePath.wstring().c_str(), SFM_WRITE, &oinfos[i]);
-                #else
+#else
                 ofiles[i] = sf_open(finalFilePath.string().c_str(), SFM_WRITE, &oinfos[i]);
-                #endif
+#endif
                 if (ofiles[i] == NULL)
                     Debug::print("Error: {}", sf_strerror(NULL));
             }
@@ -259,11 +259,11 @@ size_t SoundExporter::exportSong(const std::filesystem::path &filePath, uint16_t
             oinfo.format = SF_FORMAT_WAV | dataFormat;
             std::filesystem::path finalFilePath = filePath;
             finalFilePath += fmt::format(".wav");
-            #ifdef _WIN32
+#ifdef _WIN32
             SNDFILE *ofile = sf_wchar_open(finalFilePath.wstring().c_str(), SFM_WRITE, &oinfo);
-            #else
+#else
             SNDFILE *ofile = sf_open(finalFilePath.string().c_str(), SFM_WRITE, &oinfo);
-            #endif
+#endif
             if (ofile == NULL) {
                 Debug::print("Error: {}", sf_strerror(NULL));
                 return 0;

--- a/src/agbplay/SoundExporter.hpp
+++ b/src/agbplay/SoundExporter.hpp
@@ -26,6 +26,8 @@ public:
     void Export();
 
 private:
+    float normalizeSampleRange(float sample);
+    int32_t floatToPCM32(float sample);
     void writeSilence(sf_private_tag *ofile, double seconds);
     size_t exportSong(const std::filesystem::path &filePath, uint16_t uid);
 

--- a/src/agbplay/SoundExporter.hpp
+++ b/src/agbplay/SoundExporter.hpp
@@ -26,8 +26,6 @@ public:
     void Export();
 
 private:
-    float normalizeSampleRange(float sample);
-    int32_t floatToPCM32(float sample);
     void writeSilence(sf_private_tag *ofile, double seconds);
     size_t exportSong(const std::filesystem::path &filePath, uint16_t uid);
 


### PR DESCRIPTION
I recently tried exporting some tracks in 16-bit and 24-bit PCM, but I realized that some of them (especially those from MOTHER 2 in the 1+2 compilation (i.e. tracks 0096 and 0098)) could exceed the ranges of these formats and cause clipping, which is not the case with the 32-bit floating point format. This change request also complements request #80, which I made several months ago.

Changes:
* Ability to export to 8-bit and 32-bit PCM
  * The distinction is now made between 32-bit PCM and 32-bit floating point in the drop-down menu
* No more risk of clipping when exporting to PCM formats
  * Samples that exceed their range are automatically reduced to that range